### PR TITLE
last insert id - a question

### DIFF
--- a/lib/Mojo/SQLite.pm
+++ b/lib/Mojo/SQLite.pm
@@ -89,6 +89,12 @@ sub _dequeue {
 
   # Cache the last insert rowid on inserts
   weaken(my $weakdbh = $dbh);
+  $dbh->sqlite_set_authorizer(sub {
+    $weakdbh->{private_mojo_last_insert_id} = 0 if $_[0] == DBD::SQLite::INSERT;
+    $weakdbh->{private_mojo_last_insert_id} = 0
+      if $_[0] == DBD::SQLite::TRANSACTION && $_[1] eq 'BEGIN';
+    return DBD::SQLite::OK;
+  });
   $dbh->sqlite_update_hook(sub {
     $weakdbh->{private_mojo_last_insert_id} = $_[3] if $_[0] == DBD::SQLite::INSERT;
   });


### PR DESCRIPTION
@Grinnz I'd appreciate your thoughts/insight on this patch.

I have some code that does some `insert or ignore`, the table has a unique index, for which I'd like to simply count the successful inserts. Testing for truth of `$result->last_insert_id` seemed obvious. Having read the following I didn't expect *most recent* to survive `failed` inserts...

https://github.com/Grinnz/Mojo-SQLite/blob/9dffe657ff073f1c353a199e006cdbaa980f132b/lib/Mojo/SQLite/Results.pm#L196-L197

I expected an insert query to *clear* the `last_insert_id` as is the intent in this patch.

The same can be achieved with `localised` hash, but there's no interface for this, or by comparing to previous value of `last_insert_id`.

```perl
local $sqlite->db->dbh->{private_mojo_last_insert_id} = 0;
```

Thanks.