### PR TITLE
Use `sqlite_string_mode` not `sqlite_unicode` (#21)

### DIFF
--- a/lib/Mojo/SQLite.pm
+++ b/lib/Mojo/SQLite.pm
@@ -4,7 +4,7 @@ use Mojo::Base 'Mojo::EventEmitter';
 use Carp 'croak';
 use DBI;
 use DBD::SQLite;
-use DBD::SQLite::Constants ':database_connection_configuration_options';
+use DBD::SQLite::Constants qw(:database_connection_configuration_options :dbd_sqlite_string_mode);
 use File::Spec::Functions 'catfile';
 use File::Temp;
 use Mojo::SQLite::Database;
@@ -28,7 +28,7 @@ has options => sub {
     AutoInactiveDestroy => 1,
     PrintError          => 0,
     RaiseError          => 1,
-    sqlite_unicode      => 1,
+    sqlite_string_mode  => DBD_SQLITE_STRING_MODE_UNICODE_NAIVE,
   };
 };
 has 'parent';
@@ -359,10 +359,11 @@ more easily.
   my $options = $sql->options;
   $sql        = $sql->options({AutoCommit => 1, RaiseError => 1});
 
-Options for database handles, defaults to activating C<sqlite_unicode>,
-C<AutoCommit>, C<AutoInactiveDestroy> as well as C<RaiseError> and deactivating
-C<PrintError>. Note that C<AutoCommit> and C<RaiseError> are considered
-mandatory, so deactivating them would be very dangerous. See
+Options for database handles, defaults to setting C<sqlite_string_mode> to
+C<DBD_SQLITE_STRING_MODE_UNICODE_NAIVE>, setting C<AutoCommit>,
+C<AutoInactiveDestroy> and C<RaiseError>, and deactivating C<PrintError>.
+Note that C<AutoCommit> and C<RaiseError> are considered mandatory, so
+deactivating them would be very dangerous. See
 L<DBI/"ATTRIBUTES COMMON TO ALL HANDLES"> and
 L<DBD::SQLite/"DRIVER PRIVATE ATTRIBUTES"> for more information on available
 options.

--- a/prereqs.yml
+++ b/prereqs.yml
@@ -3,7 +3,7 @@ runtime:
     perl: '5.010001'
     Carp: 0
     DBI: '1.627'
-    DBD::SQLite: '1.64' # for JSON1, FTS5, DQS
+    DBD::SQLite: '1.68' # for JSON1, FTS5, DQS, sqlite_string_mode
     File::Spec::Functions: 0
     File::Temp: 0
     Mojolicious: '8.03'

--- a/t/connection.t
+++ b/t/connection.t
@@ -1,6 +1,8 @@
 use Mojo::Base -strict;
 
 use Test::More;
+
+use DBD::SQLite::Constants ':dbd_sqlite_string_mode';
 use Mojo::SQLite;
 use URI::file;
 
@@ -12,7 +14,7 @@ subtest 'Defaults' => sub {
     AutoInactiveDestroy => 1,
     PrintError          => 0,
     RaiseError          => 1,
-    sqlite_unicode      => 1,
+    sqlite_string_mode  => DBD_SQLITE_STRING_MODE_UNICODE_NAIVE,
   };
   is_deeply $sql->options, $options, 'right options';
 };
@@ -25,7 +27,7 @@ subtest 'Minimal connection string with file' => sub {
     AutoInactiveDestroy => 1,
     PrintError          => 0,
     RaiseError          => 1,
-    sqlite_unicode      => 1,
+    sqlite_string_mode  => DBD_SQLITE_STRING_MODE_UNICODE_NAIVE,
   };
   is_deeply $sql->options, $options, 'right options';
 };
@@ -38,7 +40,7 @@ subtest 'Minimal connection string with in-memory database and option' => sub {
     AutoInactiveDestroy => 1,
     PrintError          => 1,
     RaiseError          => 1,
-    sqlite_unicode      => 1,
+    sqlite_string_mode  => DBD_SQLITE_STRING_MODE_UNICODE_NAIVE,
   };
   is_deeply $sql->options, $options, 'right options';
 };
@@ -58,7 +60,7 @@ subtest 'Connection string with absolute filename and options' => sub {
     AutoInactiveDestroy => 1,
     PrintError          => 1,
     RaiseError          => 0,
-    sqlite_unicode      => 1,
+    sqlite_string_mode  => DBD_SQLITE_STRING_MODE_UNICODE_NAIVE,
   };
   is_deeply $sql->options, $options, 'right options';
 };
@@ -71,7 +73,7 @@ subtest 'Connection string with lots of zeros' => sub {
     AutoInactiveDestroy => 1,
     PrintError          => 0,
     RaiseError          => 0,
-    sqlite_unicode      => 1,
+    sqlite_string_mode  => DBD_SQLITE_STRING_MODE_UNICODE_NAIVE,
   };
   is_deeply $sql->options, $options, 'right options';
 };
@@ -84,7 +86,7 @@ subtest 'Parse filename' => sub {
     AutoInactiveDestroy => 1,
     PrintError          => 1,
     RaiseError          => 1,
-    sqlite_unicode      => 1,
+    sqlite_string_mode  => DBD_SQLITE_STRING_MODE_UNICODE_NAIVE,
   };
   is_deeply $sql->options, $options, 'right options';
 };


### PR DESCRIPTION
DBD::SQLite wants to move away from the use of `sqlite_unicode`
in favor of setting `sqlite_string_mode`. This requires
version 1.68 or higher of DBD::SQLite.

Signed-off-by: Adam Williamson <awilliam@redhat.com>