### PR TITLE
Fix race condition about "UNIQUE constraint failed"

### DIFF
--- a/lib/Mojo/SQLite/Migrations.pm
+++ b/lib/Mojo/SQLite/Migrations.pm
@@ -49,12 +49,8 @@ sub migrate {
   my ($up, $down) = @{$self->{migrations}}{qw(up down)};
   croak "Version $target has no migration" if $target != 0 && !$up->{$target};
 
-  # Already the right version (make sure migrations table exists)
   my $db = $self->sqlite->db;
-  return $self if $self->_active($db, 1) == $target;
-
-  # Lock migrations table and check version again
-  my $tx = $db->begin;
+  my $tx = $db->begin('exclusive');
   return $self if (my $active = $self->_active($db, 1)) == $target;
 
   # Newer version


### PR DESCRIPTION
We observed a problem where two services are accessing the same SQLite
database and one of the processes would run into an error
"DBD::SQLite::st execute failed: UNIQUE constraint failed:
mojo_migrations.name". The problem is that the method "_active" first
reads outside the database transaction lock object and then writes if no
migration table version is found so it is two queries which are not
protected from concurrent processes.

This commit removes the "optimization" attempt of reading (and writing)
outside the database transaction and only doing a single but protected
attempt. This has a potential minor performance implication but
considering that this only affects actual migrations we consider this
acceptable.

Verified within the scope of https://progress.opensuse.org/issues/108125
using the so called worker cacherservice for "openQA" with the following
command for manual verification:

```
for i in {1..10000}; do echo "## Run $i" && \
systemctl stop openqa-worker-cacheservice-minion.service openqa-worker-cacheservice.service && \
rm -f /var/lib/openqa/cache/cache.sqlite* && \
systemctl start openqa-worker-cacheservice-minion.service openqa-worker-cacheservice.service && \
for j in {1..30}; do echo "waiting for sqlite" && \
test -f /var/lib/openqa/cache/cache.sqlite && break || sleep 1; done && \
journalctl --since=today _SYSTEMD_UNIT=openqa-worker-cacheservice.service + _SYSTEMD_UNIT=openqa-worker-cacheservice-minion.service | grep -c 'UNIQUE';
done
```

Reference: https://progress.opensuse.org/issues/108125