### PR TITLE
Fix race condition about "UNIQUE constraint failed" - alternative 1

### DIFF
--- a/lib/Mojo/SQLite/Migrations.pm
+++ b/lib/Mojo/SQLite/Migrations.pm
@@ -51,7 +51,7 @@ sub migrate {
 
   # Already the right version (make sure migrations table exists)
   my $db = $self->sqlite->db;
-  return $self if $self->_active($db, 1) == $target;
+  return $self if $self->_active($db, 0) == $target;
 
   # Lock migrations table and check version again
   my $tx = $db->begin;


### PR DESCRIPTION
We observed a problem where two services are accessing the same SQLite
database and one of the processes would run into an error
"DBD::SQLite::st execute failed: UNIQUE constraint failed:
mojo_migrations.name". The problem is simple that the method "_active" already foresees to only check the version and only initializating the table within a transaction but the wrong parameter was passed :)

Verified within the scope of https://progress.opensuse.org/issues/108125
using the so called worker cacherservice for "openQA" with the following
command for manual verification:

```
for i in {1..10000}; do echo "## Run $i" && \
systemctl stop openqa-worker-cacheservice-minion.service openqa-worker-cacheservice.service && \
rm -f /var/lib/openqa/cache/cache.sqlite* && \
systemctl start openqa-worker-cacheservice-minion.service openqa-worker-cacheservice.service && \
for j in {1..30}; do echo "waiting for sqlite" && \
test -f /var/lib/openqa/cache/cache.sqlite && break || sleep 1; done && \
journalctl --since=today _SYSTEMD_UNIT=openqa-worker-cacheservice.service + _SYSTEMD_UNIT=openqa-worker-cacheservice-minion.service | grep -c 'UNIQUE';
done
```

Reference: https://progress.opensuse.org/issues/108125