### PR TITLE
Fix another race-condition on initialization

### DIFF
--- a/lib/Mojo/SQLite/Migrations.pm
+++ b/lib/Mojo/SQLite/Migrations.pm
@@ -54,7 +54,7 @@ sub migrate {
   return $self if $self->_active($db, 0) == $target;
 
   # Lock migrations table and check version again
-  my $tx = $db->begin;
+  my $tx = $db->begin('exclusive');
   return $self if (my $active = $self->_active($db, 1)) == $target;
 
   # Newer version


### PR DESCRIPTION
An exclusive access is needed to fix a race-condition of multiple
processes starting up trying to create the database file.

This is a follow-up to 5cfc9c2.

Sorry, I forgot that part in https://github.com/Grinnz/Mojo-SQLite/pull/25